### PR TITLE
Fixed URLs posted in chat not being clickable in-game

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,5 +90,8 @@ processResources
     }
 }
 
-sourceCompatibility = 1.7
-targetCompatibility = 1.7
+compileJava
+{
+    sourceCompatibility = 1.7
+    targetCompatibility = 1.7
+}

--- a/src/main/java/com/cnaude/purpleirc/PurpleIRC.java
+++ b/src/main/java/com/cnaude/purpleirc/PurpleIRC.java
@@ -66,8 +66,8 @@ import java.util.TimerTask;
 import net.minecraft.command.CommandHandler;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
+import net.minecraftforge.common.ForgeHooks;
 import net.minecraftforge.common.MinecraftForge;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -781,7 +781,7 @@ public class PurpleIRC {
     }
 
     public void broadcastToGame(final String message, final String permission) {
-        MinecraftServer.getServer().getConfigurationManager().sendChatMsg(new ChatComponentText(message));
+        MinecraftServer.getServer().getConfigurationManager().sendChatMsg(ForgeHooks.newChatWithLinks(message));
     }
 
     public EntityPlayerMP getPlayerExact(String name) {

--- a/src/main/java/com/cnaude/purpleirc/Utilities/UpdateChecker.java
+++ b/src/main/java/com/cnaude/purpleirc/Utilities/UpdateChecker.java
@@ -52,7 +52,7 @@ public class UpdateChecker {
         this.currentVersion = plugin.getDescription().getVersion();
         try {
             currentBuild = Integer.valueOf(currentVersion.split("-")[2]);
-        } catch (NumberFormatException e) {
+        } catch (Exception e) {
             currentBuild = 0;
         }
         startUpdateChecker();


### PR DESCRIPTION
This is a minor fix to the `broadcastToGame` method that makes URLs in IRC chat clickable in-game. This uses a Forge utility method which is also used by patched vanilla code. It is reliable and [appears to correctly identify and link URLs](http://i.imgur.com/SpdyOnS.png) as well as [vanilla chat can](http://i.imgur.com/HJP4QU1.png), without breaking non-URL text.
## Rationale

Players regularly share URLs in IRC chat (e.g. song of the day, FTB tutorials, etc) which in-game players have, frustratingly, been unable to click and navigate to.
## Testing
- Tested in development single-player environment with no runtime issues
- Tested as built jar in `forge-1.7.10-10.13.4.1448` local server with no compile or runtime issues
## Out-of-scope fixes

This PR has two additional but unrelated changes, for the sake of improving dev environments:
- The `sourceCompatibility` and `targetCompatibility` Gradle settings for enforcing Java language level were not picked up by my IntelliJ, as they were not in a `compileJava` block
- `UpdateChecker.java` prevented single-player worlds from loading by throwing an `ArrayIndexOutOfBoundsException`, presumably due to a blank version string. I attempted to resolve this by making it a general Exception catch.
