### PR TITLE
String.split() will always return an array with length > 0

### DIFF
--- a/src/main/java/com/cnaude/purpleirc/PurpleBot.java
+++ b/src/main/java/com/cnaude/purpleirc/PurpleBot.java
@@ -711,7 +711,7 @@ public final class PurpleBot {
 
             for (String s : config.getOption("custom-prefixes", new ArrayList<String>())) {
                 String pair[] = s.split(" ", 2);
-                if (pair.length > 0) {
+                if (pair.length > 1) {
                     userPrefixes.put(pair[0], plugin.colorConverter.translateAlternateColorCodes('&', pair[1]));
                 }
             }


### PR DESCRIPTION
Fixes #14 